### PR TITLE
add coverage for `circuit_breaker_is_flipped`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytest
 from pycarlo.common.errors import GqlError
+from pycarlo.features.circuit_breakers.exceptions import CircuitBreakerPollException
 
 from prefect_monte_carlo.credentials import MonteCarloCredentials
 
@@ -103,4 +104,12 @@ def mock_circuit_breaker_is_flipped(monkeypatch):
     monkeypatch.setattr(
         "prefect_monte_carlo.circuit_breakers.CircuitBreakerService",
         MagicMock(return_value=circuit_breaker_service),
+    )
+
+
+@pytest.fixture
+def mock_failed_polling(monkeypatch):
+    monkeypatch.setattr(
+        "prefect_monte_carlo.circuit_breakers.CircuitBreakerService.poll",
+        MagicMock(side_effect=CircuitBreakerPollException),
     )

--- a/tests/test_circuit_breakers.py
+++ b/tests/test_circuit_breakers.py
@@ -1,6 +1,7 @@
 import pytest
 from prefect import flow
 from pycarlo.common.errors import GqlError
+from pycarlo.features.circuit_breakers.exceptions import CircuitBreakerPollException
 
 from prefect_monte_carlo.circuit_breakers import (
     circuit_breaker_is_flipped,
@@ -208,12 +209,12 @@ async def test_ambiguous_rule_name_passed(
 
 
 async def test_circuit_breaker_is_not_flipped(
-    monte_carlo_creds, random_uuid, mock_circuit_breaker_is_not_flipped
+    mock_monte_carlo_creds, random_uuid, mock_circuit_breaker_is_not_flipped
 ):
     @flow
     def test_flow():
         return circuit_breaker_is_flipped(
-            monte_carlo_credentials=monte_carlo_creds, rule_uuid=random_uuid
+            monte_carlo_credentials=mock_monte_carlo_creds, rule_uuid=random_uuid
         )
 
     breaker_is_flipped = test_flow()
@@ -222,14 +223,27 @@ async def test_circuit_breaker_is_not_flipped(
 
 
 async def test_circuit_breaker_is_flipped(
-    monte_carlo_creds, random_uuid, mock_circuit_breaker_is_flipped
+    mock_monte_carlo_creds, random_uuid, mock_circuit_breaker_is_flipped
 ):
     @flow
     def test_flow():
         return circuit_breaker_is_flipped(
-            monte_carlo_credentials=monte_carlo_creds, rule_uuid=random_uuid
+            monte_carlo_credentials=mock_monte_carlo_creds, rule_uuid=random_uuid
         )
 
     breaker_is_flipped = test_flow()
 
     assert breaker_is_flipped
+
+
+async def test_circuit_breaker_poll_error_raised(
+    mock_monte_carlo_creds, random_uuid, mock_failed_polling
+):
+    @flow
+    def test_flow():
+        circuit_breaker_is_flipped(
+            monte_carlo_credentials=mock_monte_carlo_creds, rule_uuid=random_uuid
+        )
+
+    with pytest.raises(CircuitBreakerPollException):
+        test_flow()


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-monte-carlo! 🎉-->

## Summary
Adding tests to test the internal function of `circuit_breaker_is_flipped` since all existing tests simply mock its output

## Relevant Issue(s)
addresses #9 
