### PR TITLE
Return the jobTs over edgeId as it is no-longer available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- `create_or_replace_lineage_edge` now returns the `jobTs` field as `edgeId` is not available.
+
 
 ### Security
 

--- a/prefect_monte_carlo/lineage.py
+++ b/prefect_monte_carlo/lineage.py
@@ -92,7 +92,7 @@ async def create_or_update_lineage(
             # `create_or_update_lineage` is a flow, so this will be a subflow run
             # `extra_tags` are added to both the `source` and `destination` nodes
             create_or_update_lineage(
-                monte_carlo_credentials=MonteCarloCredentials.load("my-mc-creds)
+                monte_carlo_credentials=MonteCarloCredentials.load("my-mc-creds")
                 source=source,
                 destination=destination,
                 expire_at=datetime.now() + timedelta(days=10),
@@ -141,16 +141,19 @@ async def create_or_update_lineage(
     )
 
     # edge between source and destination nodes
-    edge_id = await create_or_update_lineage_edge(
+    job_timestamp = await create_or_update_lineage_edge(
         monte_carlo_credentials=monte_carlo_credentials,
         source=source,
         destination=destination,
         expire_at=expire_at,
     )
 
-    logger.info(f"Created or updated a destination lineage edge: {edge_id}")
+    logger.info(
+        f"Created or updated a destination a lineage edge between "
+        f"{source_node_url} and {destination_node_url}"
+    )
 
-    return edge_id
+    return job_timestamp
 
 
 @task(
@@ -320,7 +323,7 @@ async def create_or_update_lineage_edge(
             expireAt: $expire_at
             ){
             edge{
-                edgeId
+                jobTs
             }
             }
         }
@@ -338,6 +341,6 @@ async def create_or_update_lineage_edge(
 
     response = client(query=query, variables=variables)
 
-    edge_id = response["create_or_update_lineage_edge"]["edge"]["edge_id"]
+    job_timestamp = response["create_or_update_lineage_edge"]["edge"]["jobTs"]
 
-    return edge_id
+    return job_timestamp


### PR DESCRIPTION
After getting the error described in the issue and checking the montecarlo API docs.. there is no field `edgeId` to query. 

The only suitable field appears to be `jobTs`.

Closes [#28](https://github.com/PrefectHQ/prefect-monte-carlo/issues/28)

## Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->


## Checklist
- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-monte-carlo/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` to view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-monte-carlo/blob/main/CHANGELOG.md)
