### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_monte_carlo/credentials.py
+++ b/prefect_monte_carlo/credentials.py
@@ -4,7 +4,12 @@ from typing import Optional
 
 from prefect.blocks.core import Block
 from pycarlo.core import Client, Session
-from pydantic import Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr
+else:
+    from pydantic import Field, SecretStr
 
 
 class MonteCarloCredentials(Block):

--- a/prefect_monte_carlo/lineage.py
+++ b/prefect_monte_carlo/lineage.py
@@ -4,7 +4,12 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from prefect import flow, get_run_logger, task
-from pydantic import BaseModel, validator
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, validator
+else:
+    from pydantic import BaseModel, validator
 
 from prefect_monte_carlo.credentials import MonteCarloCredentials
 from prefect_monte_carlo.utilities import validate_tags


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.